### PR TITLE
Fixed a bug that doesn't work on Mac OSX

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = function (argv) {
       if (err)
         return console.log(err);
         
-      var exe = system == 'osx' ? '/nwjs.app/Contents/Resources/app.nw' : '/nw';
+      var exe = system == 'osx' ? '/nwjs.app/Contents/MacOS/nwjs' : '/nw';
       var nwjs = path.join(homePath(), '.nwjs/' + version + exe);
       
       spawn(nwjs, nwjsArgs)


### PR DESCRIPTION
The path is incorrect on Mac OS cause nw.js doesn't work.

It should be set to:
/nwjs.app/Contents/MacOS/nwjs