### PR TITLE
Install x64 builds on Apple Silicon macs

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -5,8 +5,15 @@
  */
 const os = require('os')
 
-const arch = os.arch()
+let arch = os.arch()
 let platform = os.platform()
+
+// there are no official arm64 builds so
+// use x64 ones on Apple Silicon macs
+if (arch === 'arm64' && platform === 'darwin') {
+  arch = 'x64'
+}
+
 if (platform === 'darwin') {
   platform = 'osx'
 } else if (platform === 'win32') {


### PR DESCRIPTION
This PR 'fixes' the HTTP 404 error when trying to install any nwjs version on an Apple Silicon mac.

```
nw install 0.58.0-sdk
```
```
Downloading 0.58.0-sdk.zip
Error: GET http://dl.nwjs.io/v0.58.0/nwjs-sdk-v0.58.0-osx-arm64.zip returned 404
Failed to install ✖ Version 0.58.0-sdk
Error: Error: GET http://dl.nwjs.io/v0.58.0/nwjs-sdk-v0.58.0-osx-arm64.zip returned 404
```